### PR TITLE
feat: add Claude Fable 5.1 model

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "prebuild": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "tsc -p tsconfig.json",
-    "test": "bun test/smoke.ts",
+    "test": "bun test/smoke.ts && bun test/models.ts",
     "test:haiku": "bun test/haiku-live.ts",
     "prepublishOnly": "npm run build"
   },

--- a/src/models.ts
+++ b/src/models.ts
@@ -50,6 +50,7 @@ const ALIAS_MODELS: ClaudeModel[] = [
 ];
 
 const PINNED_MODELS: ClaudeModel[] = [
+  model("claude-fable-5-1", "Fable 5.1", LIMIT_1M),
   model("claude-opus-4-8", "Opus 4.8", LIMIT_1M),
   model("claude-sonnet-4-6", "Sonnet 4.6", LIMIT_1M),
   model("claude-haiku-4-5", "Haiku 4.5", LIMIT_200K),

--- a/test/models.ts
+++ b/test/models.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { getClaudeModels } from "../src/models.js";
+
+const models = getClaudeModels();
+
+assert.deepEqual(
+  models.find((model) => model.id === "claude-fable-5-1"),
+  {
+    id: "claude-fable-5-1",
+    name: "Fable 5.1",
+    reasoning: true,
+    contextWindow: 1_000_000,
+    maxTokens: 128_000,
+  },
+);
+
+console.log("ok — Claude model catalog tests passed");

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -328,6 +328,16 @@ async function main() {
   assert.ok(models.length >= 4);
   assert.ok(models.some((m) => m.id === "sonnet"));
   assert.ok(models.some((m) => m.id === "opus"));
+  assert.deepEqual(
+    models.find((m) => m.id === "claude-fable-5-1"),
+    {
+      id: "claude-fable-5-1",
+      name: "Fable 5.1",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    },
+  );
   assert.equal(resolveClaudeModelId("haiku"), "claude-haiku-4-5");
   assert.equal(resolveClaudeModelId("sonnet"), "sonnet");
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -328,16 +328,6 @@ async function main() {
   assert.ok(models.length >= 4);
   assert.ok(models.some((m) => m.id === "sonnet"));
   assert.ok(models.some((m) => m.id === "opus"));
-  assert.deepEqual(
-    models.find((m) => m.id === "claude-fable-5-1"),
-    {
-      id: "claude-fable-5-1",
-      name: "Fable 5.1",
-      reasoning: true,
-      contextWindow: 1_000_000,
-      maxTokens: 128_000,
-    },
-  );
   assert.equal(resolveClaudeModelId("haiku"), "claude-haiku-4-5");
   assert.equal(resolveClaudeModelId("sonnet"), "sonnet");
 


### PR DESCRIPTION
## Summary\n- add the pinned Claude Fable 5.1 model to the Claude Code catalog\n- add focused catalog coverage for its identifier, display name, and token limits\n\n## Verification\n- bun run build\n- bun run test\n- opencode models claude-code\n- opencode run --model claude-code/claude-fable-5-1 "Reply with exactly: FABLE_5_1_OK"