### PR TITLE
fix: harden Windows CLI discovery and summary detection

### DIFF
--- a/src/executable-path.ts
+++ b/src/executable-path.ts
@@ -34,7 +34,7 @@ function knownClaudeLocations(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
 ): string[] {
   const home = typeof env.HOME === "string" && env.HOME ? env.HOME : homedir();
-  const candidates = [join(home, ".local", "bin", "claude")];
+  const candidates = executableVariants(join(home, ".local", "bin", "claude"));
 
   try {
     const prefix = spawnSync("npm", ["prefix", "-g"], {
@@ -44,11 +44,19 @@ function knownClaudeLocations(
       stdio: ["ignore", "pipe", "ignore"],
     });
     const dir = `${prefix.stdout || ""}`.trim();
-    if (dir) candidates.push(join(dir, "bin", "claude"));
+    if (dir) {
+      const globalBin = process.platform === "win32" ? dir : join(dir, "bin");
+      candidates.push(...executableVariants(join(globalBin, "claude")));
+    }
   } catch {
     // no npm prefix available — PATH and ~/.local/bin remain
   }
   return candidates;
+}
+
+function executableVariants(base: string): string[] {
+  if (process.platform !== "win32") return [base];
+  return [`${base}.cmd`, `${base}.exe`, `${base}.bat`, base];
 }
 
 export function findBinaryOnPath(
@@ -62,7 +70,7 @@ export function findBinaryOnPath(
   for (const dir of parts) {
     if (!dir) continue;
     for (const ext of exts) {
-      const candidate = `${dir.replace(/[/\\]$/, "")}/${name}${ext}`;
+      const candidate = join(dir, `${name}${ext}`);
       if (probeClaude(candidate, env)) return candidate;
     }
   }

--- a/src/request-kind.ts
+++ b/src/request-kind.ts
@@ -11,6 +11,9 @@ type MessageLike = {
   content?: unknown;
 };
 
+const OPENCODE_UPDATE_SUMMARY_PATTERN =
+  /here is the conversation so far:\s*<conversation>[\s\S]*?<\/conversation>\s*here is the summary of the conversation before the <conversation> above:\s*<prior-summary>[\s\S]*?<\/prior-summary>\s*the <prior-summary> summarizes everything that happened before the <conversation>\. construct a new summary that combines both\.[\s\S]*?output exactly the markdown structure shown inside <template>/;
+
 export function metaSystemPrompt(messages: MessageLike[]): string {
   return messages
     .filter((m) => m.role === "system")
@@ -49,6 +52,7 @@ export function isSummaryGenerationRequest(messages: MessageLike[]): boolean {
 
   const user = userText(messages).toLowerCase();
   return (
+    OPENCODE_UPDATE_SUMMARY_PATTERN.test(user) ||
     user.includes(
       "this summary will be the only context available when the conversation continues",
     ) ||

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -4,6 +4,9 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 async function main() {
   const { buildClaudeCodeChildEnv } = await import("../src/auth-env.ts");
@@ -225,20 +228,22 @@ async function main() {
     const home = mkdtempSync(join(tmpdir(), "oc-claude-home-"));
     const binDir = join(home, ".local", "bin");
     mkdirSync(binDir, { recursive: true });
-    const fake = join(binDir, "claude");
+    const fake = join(
+      binDir,
+      process.platform === "win32" ? "claude.cmd" : "claude",
+    );
     writeFileSync(
       fake,
-      '#!/bin/sh\necho "2.1.226 (Claude Code)"\n',
+      process.platform === "win32"
+        ? '@echo off\r\necho 2.1.226 (Claude Code)\r\n'
+        : '#!/bin/sh\necho "2.1.226 (Claude Code)"\n',
       { mode: 0o755 },
     );
     chmodSync(fake, 0o755);
 
     assert.equal(resolveClaudeCli({ PATH: "/usr/bin:/bin", HOME: home }), fake);
     // And PATH itself still wins when the CLI is on it.
-    assert.equal(
-      resolveClaudeCli({ PATH: "/usr/bin:/bin", HOME: home }).length > 0,
-      true,
-    );
+    assert.ok(resolveClaudeCli({ PATH: "/usr/bin:/bin", HOME: home }));
   }
 
   // The one-click install path: official npm package, script as fallback.
@@ -729,7 +734,7 @@ async function main() {
         `import { log } from "./src/log.ts"; log.info("SILENT_INFO"); log.error("ALWAYS_ERROR");`,
       ],
       {
-        cwd: new URL("..", import.meta.url).pathname,
+        cwd: PACKAGE_ROOT,
         encoding: "utf8",
         env: { ...process.env, OPENCODE_CLAUDE_DEBUG: "0" },
       },
@@ -745,7 +750,7 @@ async function main() {
         `import { log } from "./src/log.ts"; log.info("DEBUG_INFO", { ok: true });`,
       ],
       {
-        cwd: new URL("..", import.meta.url).pathname,
+        cwd: PACKAGE_ROOT,
         encoding: "utf8",
         env: { ...process.env, OPENCODE_CLAUDE_DEBUG: "1" },
       },
@@ -1835,15 +1840,26 @@ async function main() {
     // child processes that hard-block the host's event loop on every query.
     const binDir = mkdtempSync(joinPath(tmpdir(), "oc-claude-bin-"));
     try {
-      const fakeCli = joinPath(binDir, "claude");
-      writeFileSync(fakeCli, "#!/bin/sh\necho 9.9.9-smoke\n");
+      const fakeCli = joinPath(
+        binDir,
+        process.platform === "win32" ? "claude.cmd" : "claude",
+      );
+      writeFileSync(
+        fakeCli,
+        process.platform === "win32"
+          ? "@echo off\r\necho 9.9.9-smoke\r\n"
+          : "#!/bin/sh\necho 9.9.9-smoke\n",
+      );
       chmodSync(fakeCli, 0o755);
       // HOME points at the temp dir so the well-known-location fallback
       // (~/.local/bin/claude on this dev box) cannot mask a negative result.
       const env = { PATH: binDir, HOME: binDir };
       resetClaudeCliResolutionCache();
       const first = resolveClaudeCli(env);
-      assert.ok(first && first.endsWith("claude"), "fake CLI resolved");
+      assert.ok(
+        first && /[\\/]claude(?:\.cmd|\.exe|\.bat)?$/i.test(first),
+        "fake CLI resolved",
+      );
       unlinkSync(fakeCli);
       const second = resolveClaudeCli(env);
       assert.equal(second, first, "resolution must be memoized");
@@ -1863,7 +1879,7 @@ async function main() {
 
   // TypeScript build
   const build = spawnSync("bun", ["run", "build"], {
-    cwd: new URL("..", import.meta.url).pathname,
+    cwd: PACKAGE_ROOT,
     encoding: "utf8",
   });
   if (build.status !== 0) {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -711,6 +711,33 @@ async function main() {
     ];
     assert.equal(detectMetaRequestKind(summaryMessages), "summary");
 
+    const actualOpenCodeUpdateSummaryPrompt = [
+      "Here is the conversation so far:",
+      "<conversation>",
+      "User: Continue the implementation.",
+      "</conversation>",
+      "Here is the summary of the conversation before the <conversation> above:",
+      "<prior-summary>",
+      "## Objective\n- Continue the implementation",
+      "</prior-summary>",
+      "The <prior-summary> summarizes everything that happened before the <conversation>. Construct a new summary that combines both.",
+      "The <prior-summary> is discarded after this response, so preserve important information.",
+      "When combining:",
+      "- Preserve decisions and current state.",
+      "- Remove obsolete details.",
+      "Output exactly the Markdown structure shown inside <template> and keep the section order unchanged.",
+    ].join("\n");
+    assert.equal(
+      detectMetaRequestKind([{ role: "user", content: actualOpenCodeUpdateSummaryPrompt }]),
+      "summary",
+    );
+    assert.equal(
+      detectMetaRequestKind([
+        { role: "user", content: "Explain what the <prior-summary> tag means in OpenCode." },
+      ]),
+      null,
+    );
+
     const normalMessages = [
       { role: "system", content: "You are a coding assistant." },
       { role: "user", content: "fix a bug" },


### PR DESCRIPTION
## Summary
- Probe Windows Claude CLI wrapper variants (.cmd, .exe, .bat) and use platform-safe path joins.
- Convert file URLs to filesystem paths in smoke subprocesses.
- Recognize OpenCode update-summary envelopes when prose appears between the prior-summary paragraph and template instructions.
- Preserve ordinary prior-summary mentions as normal requests.

Fixes #13
Fixes #14
Follow-up to #11.

## Merge note
This PR intentionally touches src/request-kind.ts because it broadens the strict classifier introduced by PR #11. If #11 merges first, rebase this branch and retain the broader intervening-prose pattern; if this PR is reviewed first, apply its classifier hunk on top of #11 before merge.

## Verification
- bunx tsc -p tsconfig.json --noEmit
- bun test/smoke.ts
